### PR TITLE
WS1: Introduce LocalDataSource seam over Room DAO

### DIFF
--- a/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/LeisureActivityRepositoryImpl.kt
+++ b/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/LeisureActivityRepositoryImpl.kt
@@ -4,7 +4,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
-import com.uszkaisandor.bored.core.database.dao.LeisureActivityDao
+import com.uszkaisandor.bored.leisure.data.datasource.LeisureLocalDataSource
 import com.uszkaisandor.bored.leisure.data.mapper.toDomain
 import com.uszkaisandor.bored.leisure.data.seed.LeisureActivitySeeder
 import com.uszkaisandor.bored.leisure.domain.LeisureActivity
@@ -17,30 +17,31 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 
 class LeisureActivityRepositoryImpl(
-    private val dao: LeisureActivityDao,
+    private val localDataSource: LeisureLocalDataSource,
     private val seeder: LeisureActivitySeeder,
 ) : LeisureActivityRepository {
 
     override fun getRandom(type: LeisureActivityType?): Flow<LeisureActivity> = flow {
         seeder.seedIfEmpty()
-        val entity = if (type == null) dao.getRandom() else dao.getRandomByType(type.name)
+        val entity =
+            if (type == null) localDataSource.getRandom() else localDataSource.getRandomByType(type.name)
         entity ?: throw NoSuchElementException("No activities available for the current selection")
         emit(entity.toDomain())
     }.flowOn(Dispatchers.IO)
 
     override fun getActivity(id: String): Flow<LeisureActivity?> =
-        dao.getById(id)
+        localDataSource.observeById(id)
             .map { entity -> entity?.toDomain() }
             .flowOn(Dispatchers.IO)
 
     override suspend fun setIsFavourite(id: String, checked: Boolean) {
-        dao.updateFavourite(id = id, favourite = checked)
+        localDataSource.setFavourite(id = id, favourite = checked)
     }
 
     override fun getFavoriteActivities(): Flow<PagingData<LeisureActivity>> = Pager(
         config = PagingConfig(pageSize = 20)
     ) {
-        dao.getFavoriteActivities()
+        localDataSource.favouritesPagingSource()
     }.flow.map { pagingData ->
         pagingData.map { it.toDomain() }
     }

--- a/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/datasource/LeisureLocalDataSource.kt
+++ b/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/datasource/LeisureLocalDataSource.kt
@@ -1,0 +1,28 @@
+package com.uszkaisandor.bored.leisure.data.datasource
+
+import androidx.paging.PagingSource
+import com.uszkaisandor.bored.core.database.entity.LeisureActivityEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Persistence seam for leisure activities. The repository and seeder depend on this
+ * abstraction instead of the Room `LeisureActivityDao` directly, so the framework DAO
+ * stays confined to [RoomLeisureLocalDataSource] and both callers become unit-testable
+ * with a plain fake.
+ */
+interface LeisureLocalDataSource {
+
+    suspend fun getRandom(): LeisureActivityEntity?
+
+    suspend fun getRandomByType(type: String): LeisureActivityEntity?
+
+    fun observeById(id: String): Flow<LeisureActivityEntity?>
+
+    suspend fun setFavourite(id: String, favourite: Boolean)
+
+    fun favouritesPagingSource(): PagingSource<Int, LeisureActivityEntity>
+
+    suspend fun count(): Int
+
+    suspend fun insertAll(entities: List<LeisureActivityEntity>)
+}

--- a/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/datasource/RoomLeisureLocalDataSource.kt
+++ b/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/datasource/RoomLeisureLocalDataSource.kt
@@ -1,0 +1,33 @@
+package com.uszkaisandor.bored.leisure.data.datasource
+
+import androidx.paging.PagingSource
+import com.uszkaisandor.bored.core.database.dao.LeisureActivityDao
+import com.uszkaisandor.bored.core.database.entity.LeisureActivityEntity
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Room-backed [LeisureLocalDataSource]. The only place in the app that references the
+ * Room `LeisureActivityDao`.
+ */
+internal class RoomLeisureLocalDataSource(
+    private val dao: LeisureActivityDao,
+) : LeisureLocalDataSource {
+
+    override suspend fun getRandom(): LeisureActivityEntity? = dao.getRandom()
+
+    override suspend fun getRandomByType(type: String): LeisureActivityEntity? =
+        dao.getRandomByType(type)
+
+    override fun observeById(id: String): Flow<LeisureActivityEntity?> = dao.getById(id)
+
+    override suspend fun setFavourite(id: String, favourite: Boolean) =
+        dao.updateFavourite(id = id, favourite = favourite)
+
+    override fun favouritesPagingSource(): PagingSource<Int, LeisureActivityEntity> =
+        dao.getFavoriteActivities()
+
+    override suspend fun count(): Int = dao.count()
+
+    override suspend fun insertAll(entities: List<LeisureActivityEntity>) =
+        dao.insertAll(entities)
+}

--- a/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/di/LeisureDataModule.kt
+++ b/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/di/LeisureDataModule.kt
@@ -1,12 +1,15 @@
 package com.uszkaisandor.bored.leisure.data.di
 
 import com.uszkaisandor.bored.leisure.data.LeisureActivityRepositoryImpl
+import com.uszkaisandor.bored.leisure.data.datasource.LeisureLocalDataSource
+import com.uszkaisandor.bored.leisure.data.datasource.RoomLeisureLocalDataSource
 import com.uszkaisandor.bored.leisure.data.seed.LeisureActivitySeeder
 import com.uszkaisandor.bored.leisure.domain.repository.LeisureActivityRepository
 import org.koin.android.ext.koin.androidContext
 import org.koin.dsl.module
 
 val leisureDataModule = module {
+    single<LeisureLocalDataSource> { RoomLeisureLocalDataSource(get()) }
     single { LeisureActivitySeeder(androidContext(), get(), get()) }
     single<LeisureActivityRepository> { LeisureActivityRepositoryImpl(get(), get()) }
 }

--- a/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/seed/LeisureActivitySeeder.kt
+++ b/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/seed/LeisureActivitySeeder.kt
@@ -1,7 +1,7 @@
 package com.uszkaisandor.bored.leisure.data.seed
 
 import android.content.Context
-import com.uszkaisandor.bored.core.database.dao.LeisureActivityDao
+import com.uszkaisandor.bored.leisure.data.datasource.LeisureLocalDataSource
 import kotlinx.serialization.json.Json
 
 /**
@@ -10,17 +10,17 @@ import kotlinx.serialization.json.Json
  */
 class LeisureActivitySeeder(
     private val context: Context,
-    private val dao: LeisureActivityDao,
+    private val localDataSource: LeisureLocalDataSource,
     private val json: Json,
 ) {
     suspend fun seedIfEmpty() {
-        if (dao.count() > 0) return
+        if (localDataSource.count() > 0) return
         val text = context.assets
             .open(ASSET_NAME)
             .bufferedReader()
             .use { it.readText() }
         val items = json.decodeFromString<List<LeisureActivitySeedItem>>(text)
-        dao.insertAll(items.map { it.toEntity() })
+        localDataSource.insertAll(items.map { it.toEntity() })
     }
 
     private companion object {


### PR DESCRIPTION
Adds `LeisureLocalDataSource` + `RoomLeisureLocalDataSource`; the Room DAO is now referenced only in the Room implementation, and the repository/seeder depend on the abstraction.

Part of the showcase-polish stack. Base: `feature/shared-element-transition`.