### PR TITLE
WS2: Typed Outcome error handling with retry

### DIFF
--- a/core/domain/src/main/kotlin/com/uszkaisandor/bored/core/domain/result/DomainError.kt
+++ b/core/domain/src/main/kotlin/com/uszkaisandor/bored/core/domain/result/DomainError.kt
@@ -1,0 +1,20 @@
+package com.uszkaisandor.bored.core.domain.result
+
+/**
+ * Framework-agnostic error taxonomy surfaced by the domain layer. Repositories translate
+ * low-level exceptions into these cases so the presentation layer can react to intent
+ * (empty vs. not-found vs. storage failure) rather than to `Throwable` subtypes.
+ */
+sealed interface DomainError {
+    /** A query succeeded but yielded no data (e.g. no activity matches the current filter). */
+    data object Empty : DomainError
+
+    /** A specific entity was requested but does not (or no longer) exists. */
+    data object NotFound : DomainError
+
+    /** Local persistence (Room/disk) failed. */
+    data class Storage(val cause: Throwable) : DomainError
+
+    /** Anything not otherwise classified. */
+    data class Unknown(val cause: Throwable) : DomainError
+}

--- a/core/domain/src/main/kotlin/com/uszkaisandor/bored/core/domain/result/Outcome.kt
+++ b/core/domain/src/main/kotlin/com/uszkaisandor/bored/core/domain/result/Outcome.kt
@@ -1,0 +1,25 @@
+package com.uszkaisandor.bored.core.domain.result
+
+/**
+ * A success-or-typed-failure wrapper for domain operations. Prefer this over throwing so
+ * callers must handle failure explicitly and errors carry [DomainError] intent.
+ */
+sealed interface Outcome<out T> {
+    data class Success<T>(val data: T) : Outcome<T>
+    data class Failure(val error: DomainError) : Outcome<Nothing>
+}
+
+/** Maps the success value, leaving a [Outcome.Failure] untouched. */
+inline fun <T, R> Outcome<T>.map(transform: (T) -> R): Outcome<R> = when (this) {
+    is Outcome.Success -> Outcome.Success(transform(data))
+    is Outcome.Failure -> this
+}
+
+/** Collapses both branches into a single value. */
+inline fun <T, R> Outcome<T>.fold(
+    onSuccess: (T) -> R,
+    onFailure: (DomainError) -> R,
+): R = when (this) {
+    is Outcome.Success -> onSuccess(data)
+    is Outcome.Failure -> onFailure(error)
+}

--- a/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/LeisureActivityRepositoryImpl.kt
+++ b/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/LeisureActivityRepositoryImpl.kt
@@ -4,14 +4,18 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
+import com.uszkaisandor.bored.core.domain.result.DomainError
+import com.uszkaisandor.bored.core.domain.result.Outcome
 import com.uszkaisandor.bored.leisure.data.datasource.LeisureLocalDataSource
 import com.uszkaisandor.bored.leisure.data.mapper.toDomain
+import com.uszkaisandor.bored.leisure.data.mapper.toDomainError
 import com.uszkaisandor.bored.leisure.data.seed.LeisureActivitySeeder
 import com.uszkaisandor.bored.leisure.domain.LeisureActivity
 import com.uszkaisandor.bored.leisure.domain.LeisureActivityType
 import com.uszkaisandor.bored.leisure.domain.repository.LeisureActivityRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -21,17 +25,23 @@ class LeisureActivityRepositoryImpl(
     private val seeder: LeisureActivitySeeder,
 ) : LeisureActivityRepository {
 
-    override fun getRandom(type: LeisureActivityType?): Flow<LeisureActivity> = flow {
+    override fun getRandom(type: LeisureActivityType?): Flow<Outcome<LeisureActivity>> = flow {
         seeder.seedIfEmpty()
         val entity =
             if (type == null) localDataSource.getRandom() else localDataSource.getRandomByType(type.name)
-        entity ?: throw NoSuchElementException("No activities available for the current selection")
-        emit(entity.toDomain())
-    }.flowOn(Dispatchers.IO)
+        emit(
+            if (entity == null) Outcome.Failure(DomainError.Empty)
+            else Outcome.Success(entity.toDomain())
+        )
+    }.catch { emit(Outcome.Failure(it.toDomainError())) }.flowOn(Dispatchers.IO)
 
-    override fun getActivity(id: String): Flow<LeisureActivity?> =
+    override fun getActivity(id: String): Flow<Outcome<LeisureActivity>> =
         localDataSource.observeById(id)
-            .map { entity -> entity?.toDomain() }
+            .map { entity ->
+                if (entity == null) Outcome.Failure(DomainError.NotFound)
+                else Outcome.Success(entity.toDomain())
+            }
+            .catch { emit(Outcome.Failure(it.toDomainError())) }
             .flowOn(Dispatchers.IO)
 
     override suspend fun setIsFavourite(id: String, checked: Boolean) {

--- a/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/mapper/DomainErrorMappers.kt
+++ b/leisure/data/src/main/java/com/uszkaisandor/bored/leisure/data/mapper/DomainErrorMappers.kt
@@ -1,0 +1,12 @@
+package com.uszkaisandor.bored.leisure.data.mapper
+
+import android.database.SQLException
+import com.uszkaisandor.bored.core.domain.result.DomainError
+import kotlin.coroutines.cancellation.CancellationException
+
+/** Translates a low-level failure into a [DomainError] the presentation layer can act on. */
+fun Throwable.toDomainError(): DomainError = when (this) {
+    is CancellationException -> throw this // never swallow coroutine cancellation
+    is SQLException -> DomainError.Storage(this)
+    else -> DomainError.Unknown(this)
+}

--- a/leisure/domain/build.gradle.kts
+++ b/leisure/domain/build.gradle.kts
@@ -4,7 +4,8 @@ plugins {
 }
 
 dependencies {
-    implementation(project(":core:domain"))
+    // core:domain is `api` because Outcome/DomainError appear in this module's public contract.
+    api(project(":core:domain"))
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.androidx.paging.common)
     implementation(libs.kotlinx.serialization.json)

--- a/leisure/domain/src/main/kotlin/com/uszkaisandor/bored/leisure/domain/repository/LeisureActivityRepository.kt
+++ b/leisure/domain/src/main/kotlin/com/uszkaisandor/bored/leisure/domain/repository/LeisureActivityRepository.kt
@@ -1,15 +1,17 @@
 package com.uszkaisandor.bored.leisure.domain.repository
 
 import androidx.paging.PagingData
+import com.uszkaisandor.bored.core.domain.result.DomainError
+import com.uszkaisandor.bored.core.domain.result.Outcome
 import com.uszkaisandor.bored.leisure.domain.LeisureActivity
 import com.uszkaisandor.bored.leisure.domain.LeisureActivityType
 import kotlinx.coroutines.flow.Flow
 
 interface LeisureActivityRepository {
-    /** A random activity, optionally constrained to a single [type]. */
-    fun getRandom(type: LeisureActivityType? = null): Flow<LeisureActivity>
-    /** Observes a single activity by id (e.g. for a detail screen); emits null if it no longer exists. */
-    fun getActivity(id: String): Flow<LeisureActivity?>
+    /** A random activity, optionally constrained to a single [type]. Emits [DomainError.Empty] when none match. */
+    fun getRandom(type: LeisureActivityType? = null): Flow<Outcome<LeisureActivity>>
+    /** Observes a single activity by id (e.g. for a detail screen); emits [DomainError.NotFound] if it no longer exists. */
+    fun getActivity(id: String): Flow<Outcome<LeisureActivity>>
     suspend fun setIsFavourite(id: String, checked: Boolean)
     fun getFavoriteActivities(): Flow<PagingData<LeisureActivity>>
 }

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/detail/ActivityDetailScreen.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/detail/ActivityDetailScreen.kt
@@ -4,17 +4,22 @@ import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.uszkaisandor.bored.core.domain.result.DomainError
 import com.uszkaisandor.bored.core.ui.BaseScreen
 import com.uszkaisandor.bored.leisure.presentation.R
 import com.uszkaisandor.bored.leisure.presentation.navigation.sharedActivityTitle
@@ -38,10 +43,11 @@ fun ActivityDetailScreen(
                 .fillMaxSize()
                 .padding(20.dp),
         ) {
-            when {
-                state.isLoading -> CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            when (state) {
+                ActivityDetailUiState.Loading ->
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
 
-                state.activity != null -> LeisureActivityCard(
+                is ActivityDetailUiState.Content -> LeisureActivityCard(
                     modifier = Modifier.align(Alignment.TopCenter),
                     leisureActivity = state.activity,
                     onFavouriteChecked = viewModel::onFavouriteChecked,
@@ -51,11 +57,38 @@ fun ActivityDetailScreen(
                     titleModifier = Modifier.sharedActivityTitle(activityId),
                 )
 
-                else -> Text(
-                    text = stringResource(id = R.string.activity_not_found),
-                    style = MaterialTheme.typography.titleMedium,
+                is ActivityDetailUiState.Error -> DetailError(
+                    error = state.error,
+                    onRetry = viewModel::onRetry,
                     modifier = Modifier.align(Alignment.Center),
                 )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DetailError(
+    error: DomainError,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = stringResource(
+                id = if (error is DomainError.NotFound) R.string.activity_not_found else R.string.error_title
+            ),
+            style = MaterialTheme.typography.titleMedium,
+            textAlign = TextAlign.Center,
+        )
+        // A deleted activity won't come back; only offer retry for transient failures.
+        if (error !is DomainError.NotFound) {
+            OutlinedButton(onClick = onRetry) {
+                Text(text = stringResource(id = R.string.retry))
             }
         }
     }

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/detail/ActivityDetailUiState.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/detail/ActivityDetailUiState.kt
@@ -1,10 +1,11 @@
 package com.uszkaisandor.bored.leisure.presentation.detail
 
+import com.uszkaisandor.bored.core.domain.result.DomainError
 import com.uszkaisandor.bored.core.ui.UiState
 import com.uszkaisandor.bored.leisure.domain.LeisureActivity
 
-data class ActivityDetailUiState(
-    val activity: LeisureActivity? = null,
-    val isLoading: Boolean = true,
-    val notFound: Boolean = false,
-) : UiState
+sealed interface ActivityDetailUiState : UiState {
+    data object Loading : ActivityDetailUiState
+    data class Content(val activity: LeisureActivity) : ActivityDetailUiState
+    data class Error(val error: DomainError) : ActivityDetailUiState
+}

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/detail/ActivityDetailViewModel.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/detail/ActivityDetailViewModel.kt
@@ -2,11 +2,13 @@ package com.uszkaisandor.bored.leisure.presentation.detail
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.uszkaisandor.bored.core.domain.result.Outcome
 import com.uszkaisandor.bored.core.ui.BaseViewModel
 import com.uszkaisandor.bored.leisure.domain.repository.LeisureActivityRepository
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 
 class ActivityDetailViewModel(
@@ -14,16 +16,28 @@ class ActivityDetailViewModel(
     private val activityId: String,
 ) : ViewModel(), BaseViewModel<ActivityDetailUiState> {
 
-    private val _uiState = MutableStateFlow(ActivityDetailUiState())
+    private val _uiState = MutableStateFlow<ActivityDetailUiState>(ActivityDetailUiState.Loading)
     override val uiState = _uiState.asStateFlow()
 
+    private var observeJob: Job? = null
+
     init {
-        viewModelScope.launch {
-            repository.getActivity(activityId).collect { activity ->
-                _uiState.update {
-                    it.copy(activity = activity, isLoading = false, notFound = activity == null)
+        observeActivity()
+    }
+
+    fun onRetry() = observeActivity()
+
+    private fun observeActivity() {
+        observeJob?.cancel()
+        observeJob = viewModelScope.launch {
+            repository.getActivity(activityId)
+                .onStart { _uiState.value = ActivityDetailUiState.Loading }
+                .collect { outcome ->
+                    _uiState.value = when (outcome) {
+                        is Outcome.Success -> ActivityDetailUiState.Content(outcome.data)
+                        is Outcome.Failure -> ActivityDetailUiState.Error(outcome.error)
+                    }
                 }
-            }
         }
     }
 

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/favourites/FavouriteActivitiesList.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/favourites/FavouriteActivitiesList.kt
@@ -12,9 +12,13 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
+import com.uszkaisandor.bored.leisure.presentation.R
 import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.itemKey
@@ -63,8 +67,18 @@ fun FavouriteActivitiesList(
             }
         }
         item {
-            if (pagingItems.loadState.append is LoadState.Loading) {
-                CircularProgressIndicator(modifier = Modifier.padding(16.dp))
+            when (pagingItems.loadState.append) {
+                is LoadState.Loading ->
+                    CircularProgressIndicator(modifier = Modifier.padding(16.dp))
+
+                is LoadState.Error -> TextButton(
+                    onClick = pagingItems::retry,
+                    modifier = Modifier.padding(8.dp),
+                ) {
+                    Text(text = stringResource(id = R.string.retry))
+                }
+
+                else -> Unit
             }
         }
     }

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/favourites/FavouriteActivitiesScreen.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/favourites/FavouriteActivitiesScreen.kt
@@ -1,14 +1,20 @@
 package com.uszkaisandor.bored.leisure.presentation.favourites
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import com.uszkaisandor.bored.leisure.presentation.R
@@ -19,26 +25,52 @@ fun FavouriteActivitiesScreen(
     onActivityClick: (String) -> Unit,
     viewModel: FavouriteActivitiesViewModel = koinViewModel(),
 ) {
-    val uiState by viewModel.uiState.collectAsState()
-
     val pagingItems = viewModel.activityPagingDataFlow.collectAsLazyPagingItems()
+    val refresh = pagingItems.loadState.refresh
 
     Box(modifier = Modifier.fillMaxSize()) {
-        if (pagingItems.loadState.refresh is LoadState.Loading && pagingItems.itemCount == 0) {
-            CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
-        } else {
-            if (pagingItems.itemCount == 0) {
-                EmptyListState(
-                    lottieResId = R.raw.empty_favourites,
-                    title = stringResource(id = R.string.favourites_empty_title)
+        when {
+            refresh is LoadState.Loading && pagingItems.itemCount == 0 ->
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+
+            refresh is LoadState.Error && pagingItems.itemCount == 0 ->
+                FavouritesError(
+                    onRetry = pagingItems::retry,
+                    modifier = Modifier.align(Alignment.Center),
                 )
-            } else {
-                FavouriteActivitiesList(
-                    pagingItems = pagingItems,
-                    onSwipedToDelete = viewModel::onSwipedToDelete,
-                    onActivityClick = onActivityClick,
-                )
-            }
+
+            pagingItems.itemCount == 0 -> EmptyListState(
+                lottieResId = R.raw.empty_favourites,
+                title = stringResource(id = R.string.favourites_empty_title)
+            )
+
+            else -> FavouriteActivitiesList(
+                pagingItems = pagingItems,
+                onSwipedToDelete = viewModel::onSwipedToDelete,
+                onActivityClick = onActivityClick,
+            )
+        }
+    }
+}
+
+@Composable
+private fun FavouritesError(
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = stringResource(id = R.string.error_title),
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onBackground,
+            textAlign = TextAlign.Center,
+        )
+        OutlinedButton(onClick = onRetry) {
+            Text(text = stringResource(id = R.string.retry))
         }
     }
 }

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/home/HomeScreen.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/home/HomeScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -30,11 +31,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.uszkaisandor.bored.core.designsystem.AppTheme
 import com.uszkaisandor.bored.core.designsystem.Typography
+import com.uszkaisandor.bored.core.domain.result.DomainError
 import com.uszkaisandor.bored.core.ui.BaseScreen
 import com.uszkaisandor.bored.core.ui.rememberAppHaptics
 import com.uszkaisandor.bored.leisure.domain.LeisureActivity
 import com.uszkaisandor.bored.leisure.domain.LeisureActivityType
 import com.uszkaisandor.bored.leisure.presentation.R
+import com.uszkaisandor.bored.leisure.presentation.home.HomeUiState.ActivityState
 import com.uszkaisandor.bored.leisure.presentation.views.LeisureActivityCard
 import org.koin.androidx.compose.koinViewModel
 
@@ -49,7 +52,7 @@ fun HomeScreen(
         ) { _ -> }
         val haptics = rememberAppHaptics()
 
-        rememberShakeDetector(enabled = !uiState.isLoading) {
+        rememberShakeDetector(enabled = uiState.activityState !is ActivityState.Loading) {
             haptics.shuffle()
             viewModel.onButtonClicked()
         }
@@ -69,25 +72,41 @@ fun HomeScreen(
                     .weight(1f)
                     .fillMaxWidth()
             ) {
-                if (uiState.hasError) {
-                    ErrorContent(modifier = Modifier.align(Alignment.Center))
-                } else {
-                    AnimatedContent(
-                        targetState = uiState.currentLeisureActivity,
-                        modifier = Modifier.align(Alignment.Center),
-                        transitionSpec = {
-                            (fadeIn() + scaleIn(initialScale = 0.92f)) togetherWith fadeOut()
-                        },
-                        contentKey = { it?.id },
-                        label = "activity-reveal",
-                    ) { activity ->
-                        LeisureActivityCard(
+                AnimatedContent(
+                    targetState = uiState.activityState,
+                    modifier = Modifier.align(Alignment.Center),
+                    transitionSpec = {
+                        (fadeIn() + scaleIn(initialScale = 0.92f)) togetherWith fadeOut()
+                    },
+                    contentKey = { state ->
+                        when (state) {
+                            ActivityState.Loading -> "loading"
+                            is ActivityState.Content -> state.activity.id
+                            is ActivityState.Error -> "error"
+                        }
+                    },
+                    label = "activity-reveal",
+                ) { state ->
+                    when (state) {
+                        ActivityState.Loading -> LeisureActivityCard(
                             modifier = Modifier.padding(20.dp),
-                            leisureActivity = activity,
+                            leisureActivity = null,
+                            onFavouriteChecked = {},
+                            onLinkClicked = {},
+                        )
+
+                        is ActivityState.Content -> LeisureActivityCard(
+                            modifier = Modifier.padding(20.dp),
+                            leisureActivity = state.activity,
                             onFavouriteChecked = viewModel::onFavouriteChecked,
                             onLinkClicked = {
                                 openUrlLauncher.launch(Intent(Intent.ACTION_VIEW, Uri.parse(it)))
                             }
+                        )
+
+                        is ActivityState.Error -> ErrorContent(
+                            error = state.error,
+                            onRetry = viewModel::onRetry,
                         )
                     }
                 }
@@ -114,7 +133,15 @@ fun HomeScreen(
 }
 
 @Composable
-private fun ErrorContent(modifier: Modifier = Modifier) {
+private fun ErrorContent(
+    error: DomainError,
+    onRetry: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val messageRes = when (error) {
+        DomainError.Empty -> R.string.error_empty
+        else -> R.string.error_title
+    }
     Column(
         modifier = modifier.padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -122,11 +149,15 @@ private fun ErrorContent(modifier: Modifier = Modifier) {
         Text(text = "😕", fontSize = 48.sp)
         Spacer(modifier = Modifier.height(12.dp))
         Text(
-            text = stringResource(id = R.string.error_title),
+            text = stringResource(id = messageRes),
             style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onBackground,
             textAlign = TextAlign.Center,
         )
+        Spacer(modifier = Modifier.height(16.dp))
+        OutlinedButton(onClick = onRetry) {
+            Text(text = stringResource(id = R.string.retry))
+        }
     }
 }
 

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/home/HomeUiState.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/home/HomeUiState.kt
@@ -1,12 +1,22 @@
 package com.uszkaisandor.bored.leisure.presentation.home
 
+import com.uszkaisandor.bored.core.domain.result.DomainError
 import com.uszkaisandor.bored.core.ui.UiState
 import com.uszkaisandor.bored.leisure.domain.LeisureActivity
 import com.uszkaisandor.bored.leisure.domain.LeisureActivityType
 
+/**
+ * The category filter row is always visible ([selectedType]); the card area swaps between
+ * the [ActivityState] variants.
+ */
 data class HomeUiState(
-    val currentLeisureActivity: LeisureActivity? = null,
     val selectedType: LeisureActivityType? = null,
-    val isLoading: Boolean = false,
-    val hasError: Boolean = false,
-) : UiState
+    val activityState: ActivityState = ActivityState.Loading,
+) : UiState {
+
+    sealed interface ActivityState {
+        data object Loading : ActivityState
+        data class Content(val activity: LeisureActivity) : ActivityState
+        data class Error(val error: DomainError) : ActivityState
+    }
+}

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/home/HomeViewModel.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/home/HomeViewModel.kt
@@ -2,12 +2,13 @@ package com.uszkaisandor.bored.leisure.presentation.home
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.uszkaisandor.bored.core.domain.result.Outcome
 import com.uszkaisandor.bored.core.ui.BaseViewModel
 import com.uszkaisandor.bored.leisure.domain.LeisureActivityType
 import com.uszkaisandor.bored.leisure.domain.repository.LeisureActivityRepository
+import com.uszkaisandor.bored.leisure.presentation.home.HomeUiState.ActivityState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
@@ -28,23 +29,23 @@ class HomeViewModel(
         val type = uiState.value.selectedType
         viewModelScope.launch {
             repository.getRandom(type)
-                .onStart { _uiState.update { it.copy(isLoading = true, hasError = false) } }
-                .catch { _uiState.update { it.copy(isLoading = false, hasError = true) } }
-                .collectLatest { activity ->
+                .onStart { _uiState.update { it.copy(activityState = ActivityState.Loading) } }
+                .collectLatest { outcome ->
                     _uiState.update {
                         it.copy(
-                            currentLeisureActivity = activity,
-                            isLoading = false,
-                            hasError = false,
+                            activityState = when (outcome) {
+                                is Outcome.Success -> ActivityState.Content(outcome.data)
+                                is Outcome.Failure -> ActivityState.Error(outcome.error)
+                            }
                         )
                     }
                 }
         }
     }
 
-    fun onButtonClicked() {
-        getRandomActivity()
-    }
+    fun onButtonClicked() = getRandomActivity()
+
+    fun onRetry() = getRandomActivity()
 
     fun onTypeSelected(type: LeisureActivityType?) {
         if (type == uiState.value.selectedType) return
@@ -53,11 +54,25 @@ class HomeViewModel(
     }
 
     fun onFavouriteChecked(isChecked: Boolean) {
-        val current = uiState.value.currentLeisureActivity ?: return
+        val state = uiState.value.activityState
+        if (state !is ActivityState.Content) return
+        val activity = state.activity
+        // Optimistic toggle; roll back if persistence fails.
+        _uiState.update {
+            it.copy(activityState = ActivityState.Content(activity.copy(isFavourite = isChecked)))
+        }
         viewModelScope.launch {
-            _uiState.update { it.copy(currentLeisureActivity = current.copy(isFavourite = isChecked)) }
-            repository.setIsFavourite(current.id, isChecked)
+            runCatching { repository.setIsFavourite(activity.id, isChecked) }
+                .onFailure {
+                    _uiState.update { current ->
+                        val now = current.activityState
+                        if (now is ActivityState.Content && now.activity.id == activity.id) {
+                            current.copy(activityState = ActivityState.Content(activity))
+                        } else {
+                            current
+                        }
+                    }
+                }
         }
     }
-
 }

--- a/leisure/presentation/src/main/res/values/strings.xml
+++ b/leisure/presentation/src/main/res/values/strings.xml
@@ -4,6 +4,7 @@
     <string name="activity_not_found">This activity is no longer available.</string>
     <string name="learn_more">Learn more</string>
     <string name="error_title">Couldn\'t load an activity</string>
+    <string name="error_empty">No activities match this filter</string>
     <string name="retry">Try again</string>
     <string name="accessibility">Accessibility</string>
     <string name="price_range">Price range</string>

--- a/widget/src/main/java/com/uszkaisandor/bored/widget/BoredWidget.kt
+++ b/widget/src/main/java/com/uszkaisandor/bored/widget/BoredWidget.kt
@@ -24,6 +24,7 @@ import androidx.glance.layout.padding
 import androidx.glance.text.FontWeight
 import androidx.glance.text.Text
 import androidx.glance.text.TextStyle
+import com.uszkaisandor.bored.core.domain.result.Outcome
 import com.uszkaisandor.bored.leisure.domain.LeisureActivity
 import com.uszkaisandor.bored.leisure.domain.repository.LeisureActivityRepository
 import kotlinx.coroutines.flow.first
@@ -38,7 +39,9 @@ class BoredWidget : GlanceAppWidget() {
 
     override suspend fun provideGlance(context: Context, id: GlanceId) {
         val repository: LeisureActivityRepository = GlobalContext.get().get()
-        val activity = runCatching { repository.getRandom().first() }.getOrNull()
+        val activity = runCatching {
+            (repository.getRandom().first() as? Outcome.Success)?.data
+        }.getOrNull()
 
         provideContent {
             GlanceTheme {


### PR DESCRIPTION
Introduces `Outcome`/`DomainError` in core:domain, threaded through repository → ViewModel → sealed UiState. Adds retry and optimistic-favourite rollback; unifies error signalling.

Stacked on WS1. Base: `feature/local-datasource-seam`.