### PR TITLE
WS5: Design-system polish and swipe-delete fix

### DIFF
--- a/app/src/main/java/com/uszkaisandor/bored/presentation/app/DailyTipBanner.kt
+++ b/app/src/main/java/com/uszkaisandor/bored/presentation/app/DailyTipBanner.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -20,7 +19,7 @@ fun DailyTipBanner(tip: String) {
         modifier = Modifier
             .fillMaxWidth()
             .padding(horizontal = 20.dp, vertical = 8.dp)
-            .clip(RoundedCornerShape(16.dp))
+            .clip(MaterialTheme.shapes.medium)
             .background(MaterialTheme.colorScheme.primaryContainer)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         verticalAlignment = Alignment.CenterVertically,

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/favourites/FavouriteActivitiesList.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/favourites/FavouriteActivitiesList.kt
@@ -10,8 +10,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -46,7 +46,7 @@ fun FavouriteActivitiesList(
         ) { index ->
             pagingItems[index]?.let {
                 SwipeToDeleteBox(
-                    shape = RoundedCornerShape(16.dp),
+                    shape = MaterialTheme.shapes.medium,
                     onDelete = {
                         onSwipedToDelete(it.id)
                     }

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/home/HomeScreen.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/home/HomeScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.uszkaisandor.bored.core.designsystem.AppTheme
-import com.uszkaisandor.bored.core.designsystem.Typography
 import com.uszkaisandor.bored.core.domain.result.DomainError
 import com.uszkaisandor.bored.core.ui.BaseScreen
 import com.uszkaisandor.bored.core.ui.rememberAppHaptics
@@ -124,7 +123,7 @@ fun HomeScreen(
             ) {
                 Text(
                     text = stringResource(id = R.string.get_new_activity),
-                    style = Typography.labelLarge,
+                    style = MaterialTheme.typography.labelLarge,
                     color = MaterialTheme.colorScheme.onPrimary
                 )
             }

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/views/LeisureActivityListItem.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/views/LeisureActivityListItem.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -17,7 +16,6 @@ import androidx.compose.ui.unit.dp
 import com.uszkaisandor.bored.leisure.domain.LeisureActivity
 import com.uszkaisandor.bored.leisure.presentation.home.sampleLeisureActivity
 import com.uszkaisandor.bored.core.designsystem.AppTheme
-import com.uszkaisandor.bored.core.designsystem.Typography
 
 @Composable
 fun LeisureActivityListItem(
@@ -31,7 +29,7 @@ fun LeisureActivityListItem(
             .wrapContentHeight()
             .background(
                 color = MaterialTheme.colorScheme.surfaceContainer,
-                shape = RoundedCornerShape(16.dp)
+                shape = MaterialTheme.shapes.medium
             ),
         contentAlignment = Alignment.CenterStart
     ) {
@@ -40,7 +38,7 @@ fun LeisureActivityListItem(
                 .padding(horizontal = 16.dp, vertical = 16.dp),
             text = leisureActivity.name,
             textAlign = TextAlign.Start,
-            style = Typography.titleMedium,
+            style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurface
         )
     }

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/views/SwipeToDeleteBox.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/views/SwipeToDeleteBox.kt
@@ -17,10 +17,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import com.uszkaisandor.bored.core.ui.rememberAppHaptics
 import com.uszkaisandor.bored.leisure.presentation.R
@@ -43,28 +41,10 @@ fun SwipeToDeleteBox(
         }
     }
 
-    lateinit var icon: ImageVector
-    lateinit var alignment: Alignment
-    val color: Color
-
-    when (swipeState.dismissDirection) {
-        SwipeToDismissBoxValue.EndToStart -> {
-            icon = Icons.Default.Delete
-            alignment = Alignment.CenterEnd
-            color = MaterialTheme.colorScheme.errorContainer
-        }
-
-
-        SwipeToDismissBoxValue.Settled -> {
-            icon = Icons.Default.Delete
-            alignment = Alignment.CenterEnd
-            color = MaterialTheme.colorScheme.errorContainer
-        }
-
-        SwipeToDismissBoxValue.StartToEnd -> {
-            icon = Icons.Default.Delete
-            alignment = Alignment.CenterStart
-            color = MaterialTheme.colorScheme.errorContainer
+    // Fire the delete exactly once, as a keyed side-effect — not during composition.
+    LaunchedEffect(swipeState.currentValue) {
+        if (swipeState.currentValue == SwipeToDismissBoxValue.EndToStart) {
+            onDelete()
         }
     }
 
@@ -74,14 +54,14 @@ fun SwipeToDeleteBox(
         enableDismissFromStartToEnd = false,
         backgroundContent = {
             Box(
-                contentAlignment = alignment,
+                contentAlignment = Alignment.CenterEnd,
                 modifier = Modifier
                     .fillMaxSize()
-                    .background(color = color, shape = shape)
+                    .background(color = MaterialTheme.colorScheme.errorContainer, shape = shape)
             ) {
                 Icon(
                     modifier = Modifier.minimumInteractiveComponentSize(),
-                    imageVector = icon,
+                    imageVector = Icons.Default.Delete,
                     tint = MaterialTheme.colorScheme.onErrorContainer,
                     contentDescription = stringResource(R.string.delete_activity)
                 )
@@ -89,13 +69,5 @@ fun SwipeToDeleteBox(
         }
     ) {
         content()
-    }
-
-    when (swipeState.currentValue) {
-        SwipeToDismissBoxValue.EndToStart -> {
-            onDelete()
-        }
-
-        SwipeToDismissBoxValue.StartToEnd, SwipeToDismissBoxValue.Settled -> Unit
     }
 }

--- a/leisure/presentation/src/main/res/values/strings.xml
+++ b/leisure/presentation/src/main/res/values/strings.xml
@@ -18,10 +18,8 @@
     <string name="relaxation">Relaxation</string>
     <string name="music">Music</string>
     <string name="busywork">Busywork</string>
-    <string name="participants">Participants</string>
 
     <string name="favourites_empty_title">There are no favourite activities. To add any, tap the heart icon on any activity card.</string>
-    <string name="category">Category: %1$s</string>
 
     <string name="add_to_favourites">Add to favourites</string>
     <string name="remove_from_favourites">Remove from favourites</string>


### PR DESCRIPTION
Fixes the swipe-to-delete side effect (now a keyed LaunchedEffect), unifies shape/type tokens, and removes dead strings.

Stacked on WS4. Base: `feature/ci-and-quality-gates`.