### PR TITLE
WS6: Accessibility semantics and i18n

### DIFF
--- a/app/src/main/java/com/uszkaisandor/bored/presentation/app/BoredApp.kt
+++ b/app/src/main/java/com/uszkaisandor/bored/presentation/app/BoredApp.kt
@@ -14,8 +14,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringArrayResource
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.navigation3.ui.NavDisplay
+import com.uszkaisandor.bored.R
 import com.uszkaisandor.bored.leisure.presentation.navigation.HomeKey
 import com.uszkaisandor.bored.leisure.presentation.navigation.LocalSharedTransitionScope
 import com.uszkaisandor.bored.leisure.presentation.navigation.leisureEntry
@@ -32,7 +34,8 @@ fun BoredApp(modifier: Modifier = Modifier) {
         bottomBar = { BottomBar(backStack) }
     ) { paddingValues ->
         Column(modifier = Modifier.padding(paddingValues)) {
-            DailyTipBanner(tip = DailyTipProvider.getTipForToday())
+            val tips = stringArrayResource(R.array.daily_tips)
+            DailyTipBanner(tip = tips[DailyTipProvider.todayIndex(tips.size)])
             SharedTransitionLayout {
               CompositionLocalProvider(LocalSharedTransitionScope provides this) {
                 NavDisplay(

--- a/app/src/main/java/com/uszkaisandor/bored/presentation/app/DailyTipBanner.kt
+++ b/app/src/main/java/com/uszkaisandor/bored/presentation/app/DailyTipBanner.kt
@@ -10,6 +10,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.LiveRegionMode
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.semantics.liveRegion
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 
@@ -21,10 +25,18 @@ fun DailyTipBanner(tip: String) {
             .padding(horizontal = 20.dp, vertical = 8.dp)
             .clip(MaterialTheme.shapes.medium)
             .background(MaterialTheme.colorScheme.primaryContainer)
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+            .padding(horizontal = 16.dp, vertical = 12.dp)
+            // Announce the tip when it changes; the text alone carries the meaning.
+            .semantics { liveRegion = LiveRegionMode.Polite },
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(text = "💡", fontSize = 20.sp, modifier = Modifier.padding(end = 12.dp))
+        Text(
+            text = "💡",
+            fontSize = 20.sp,
+            modifier = Modifier
+                .padding(end = 12.dp)
+                .clearAndSetSemantics { },
+        )
         Text(
             text = tip,
             style = MaterialTheme.typography.bodyMedium,

--- a/app/src/main/java/com/uszkaisandor/bored/presentation/app/DailyTipProvider.kt
+++ b/app/src/main/java/com/uszkaisandor/bored/presentation/app/DailyTipProvider.kt
@@ -1,23 +1,11 @@
 package com.uszkaisandor.bored.presentation.app
 
+/** Picks a stable daily index into the `daily_tips` string-array (rotates once per day). */
 object DailyTipProvider {
-    private val tips = listOf(
-        "Try something new today!",
-        "Take a short walk to refresh your mind.",
-        "Call a friend you haven't talked to in a while.",
-        "Read a few pages from a book.",
-        "Write down three things you're grateful for.",
-        "Listen to your favorite song.",
-        "Plan a fun activity for the weekend.",
-        "Drink a glass of water!",
-        "Smile at someone today.",
-        "Take a deep breath and relax."
-    )
-
-    fun getTipForToday(): String {
+    fun todayIndex(tipCount: Int): Int {
+        if (tipCount <= 0) return 0
         val millisInDay = 24 * 60 * 60 * 1000L
         val todayEpochDay = System.currentTimeMillis() / millisInDay
-        val index = (todayEpochDay % tips.size).toInt()
-        return tips[index]
+        return (todayEpochDay % tipCount).toInt()
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -3,4 +3,17 @@
     <string name="home_tab_title">Random activity</string>
     <string name="favourite_tab_title">Favourites</string>
     <string name="settings_tab_title">Settings</string>
+
+    <string-array name="daily_tips">
+        <item>Try something new today!</item>
+        <item>Take a short walk to refresh your mind.</item>
+        <item>Call a friend you haven\'t talked to in a while.</item>
+        <item>Read a few pages from a book.</item>
+        <item>Write down three things you\'re grateful for.</item>
+        <item>Listen to your favorite song.</item>
+        <item>Plan a fun activity for the weekend.</item>
+        <item>Drink a glass of water!</item>
+        <item>Smile at someone today.</item>
+        <item>Take a deep breath and relax.</item>
+    </string-array>
 </resources>

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/favourites/FavouriteActivitiesList.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/favourites/FavouriteActivitiesList.kt
@@ -17,6 +17,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.dp
 import com.uszkaisandor.bored.leisure.presentation.R
 import androidx.paging.LoadState
@@ -51,6 +52,7 @@ fun FavouriteActivitiesList(
                         onSwipedToDelete(it.id)
                     }
                 ) {
+                    val openLabel = stringResource(id = R.string.open_activity)
                     LeisureActivityListItem(
                         modifier = Modifier
                             .animateItem(
@@ -59,7 +61,9 @@ fun FavouriteActivitiesList(
                                     easing = FastOutLinearInEasing
                                 )
                             )
-                            .clickable { onActivityClick(it.id) },
+                            .clickable(role = Role.Button, onClickLabel = openLabel) {
+                                onActivityClick(it.id)
+                            },
                         leisureActivity = it,
                         titleModifier = Modifier.sharedActivityTitle(it.id),
                     )

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/home/HomeScreen.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/home/HomeScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.clearAndSetSemantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -145,7 +146,7 @@ private fun ErrorContent(
         modifier = modifier.padding(24.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Text(text = "😕", fontSize = 48.sp)
+        Text(text = "😕", fontSize = 48.sp, modifier = Modifier.clearAndSetSemantics { })
         Spacer(modifier = Modifier.height(12.dp))
         Text(
             text = stringResource(id = messageRes),

--- a/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/views/LeisureActivityCard.kt
+++ b/leisure/presentation/src/main/java/com/uszkaisandor/bored/leisure/presentation/views/LeisureActivityCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.MaterialShapes
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.minimumInteractiveComponentSize
 import androidx.compose.material3.toShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -35,6 +36,7 @@ import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
@@ -107,7 +109,9 @@ fun LeisureActivityCard(
                     activity.link?.let { url ->
                         Text(
                             text = stringResource(id = R.string.learn_more),
-                            modifier = Modifier.clickable { onLinkClicked(url) },
+                            modifier = Modifier
+                                .minimumInteractiveComponentSize()
+                                .clickable(role = Role.Button) { onLinkClicked(url) },
                             style = MaterialTheme.typography.bodyLarge,
                             color = ExtendedTheme.colors.link,
                             textDecoration = TextDecoration.Underline,

--- a/leisure/presentation/src/main/res/values/strings.xml
+++ b/leisure/presentation/src/main/res/values/strings.xml
@@ -21,6 +21,7 @@
 
     <string name="favourites_empty_title">There are no favourite activities. To add any, tap the heart icon on any activity card.</string>
 
+    <string name="open_activity">Open activity details</string>
     <string name="add_to_favourites">Add to favourites</string>
     <string name="remove_from_favourites">Remove from favourites</string>
     <string name="delete_activity">Delete activity</string>


### PR DESCRIPTION
Adds link/list-item semantics and 48dp touch targets, a live-region daily tip, decorative-emoji semantics, and moves the daily tips into a string-array.

Stacked on WS5. Base: `feature/design-system-polish`.