### PR TITLE
Enable parallel build, build and configuration cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -7,10 +7,11 @@
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
 org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
-# When configured, Gradle will run in incubating parallel mode.
-# This option should only be used with decoupled projects. More details, visit
-# http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
-# org.gradle.parallel=true
+# Build performance: parallel module execution, build cache and configuration cache.
+org.gradle.parallel=true
+org.gradle.caching=true
+org.gradle.configuration-cache=true
+org.gradle.configuration-cache.parallel=true
 # AndroidX package structure to make it clearer which packages are bundled with the
 # Android operating system, and which are packaged with your app's APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn


### PR DESCRIPTION
Turns on `org.gradle.parallel`, `org.gradle.caching` and `org.gradle.configuration-cache` (with parallel config cache). Verified: config cache stores and reuses cleanly across assemble/test/lint on the AGP 9 / KSP2 toolchain — no configuration-cache problems.