### PR TITLE
Point CI at main after default-branch rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master, develop ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ master, develop ]
+    branches: [ main, develop ]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
Updates the CI push/pull_request triggers from `master` to `main` so the pipeline runs on the renamed default branch.